### PR TITLE
Remove unnecessary Log in link which looked wrong on mobile

### DIFF
--- a/lib/casserver/views/layout.erb
+++ b/lib/casserver/views/layout.erb
@@ -57,9 +57,6 @@
                       <li><a class="" href="//<%= @domain %>/apply">For Students</a></li>
                       <li><a class="" href="//<%= @domain %>/volunteer">For Volunteers</a></li>
                       <li><a class="" href="//<%= @domain %>/partner">For Partners</a></li>
-                      <li>   <a href="//<%= @domain %>/users/sign_in_sso">Log In</a>
-
-</li>
                     </ul>
                   </div>
                 </div>

--- a/lib/casserver/views/login.erb
+++ b/lib/casserver/views/login.erb
@@ -1,6 +1,6 @@
 <%# coding: UTF-8 -%>
 
-<div class="plank plain-md">
+<div class="plank plain-md" style="min-height: 700px; padding-top: 32px;">
   <div class="section-container">
     <section>
       <div class="col-md-4 col-md-offset-4">


### PR DESCRIPTION
This wrapped to the next line on mobile breaking the responsive look, and it is totally useless anyway because this IS the log in page, so no need to link it again. I decided to simply remove it.