### PR TITLE
Responsive bit for login on small phone screens

### DIFF
--- a/lib/casserver/views/layout.erb
+++ b/lib/casserver/views/layout.erb
@@ -140,6 +140,36 @@ made with<span class="heart" style="display: inline;"> <img style="display: inli
 			</div><!-- .site-info -->
 		</div>
     </div> <!-- .public-container -->
+
+
+
+
+<!-- all this crap is here just for the  mobile hotdog menu -->
+
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.min.js"></script>
+<script type="text/javascript" src="//join.bebraven.org/bebraven/jquery.mmenu.min.all.js"></script>
+<script>
+$(document).ready(function($) {
+$('nav#menu').mmenu({
+  navbar: {
+    title: "Braven"
+  }
+  });
+  
+     var API = $("#menu").data( "mmenu" );
+
+      $("#close-mobile-btn").click(function() {
+         API.close();
+      });
+			});
+	
+</script>
+    
+<!-- done -->
+
+
+
 </body>
 
 

--- a/public/bebraven/trimmed.css
+++ b/public/bebraven/trimmed.css
@@ -1395,6 +1395,16 @@ li > ul {
 	main > .plank .section-container > section > div.col-md-4 {
 		padding-top: 4px;
 	}
+
+	main input.button-primary {
+		width: 100%;
+	}
+
+	/* hide everything under it too because we want to keep it simple on phone,
+	   they can always use the hot dog menu */
+	form ~ * {
+		display: none;
+	}
 }
 
 @media print {

--- a/public/bebraven/trimmed.css
+++ b/public/bebraven/trimmed.css
@@ -1,679 +1,1033 @@
 @font-face {
-	font-family:'TradeGothic';
+	font-family: 'TradeGothic';
 	src: url('TradeGothicNo.20-CondBold_gdi.eot');
 	src: url('TradeGothicNo.20-CondBold_gdi.eot?#iefix') format('embedded-opentype'),
-		url('TradeGothicNo.20-CondBold_gdi.woff') format('woff'),
-		url('TradeGothicNo.20-CondBold_gdi.ttf') format('truetype'),
-		url('TradeGothicNo.20-CondBold_gdi.svg#TradeGothicNo.20-CondBold') format('svg');
+			url('TradeGothicNo.20-CondBold_gdi.woff') format('woff'),
+			url('TradeGothicNo.20-CondBold_gdi.ttf') format('truetype'),
+			url('TradeGothicNo.20-CondBold_gdi.svg#TradeGothicNo.20-CondBold') format('svg');
 	font-weight: 700;
 	font-style: normal;
 	font-stretch: expanded;
 	unicode-range: U+0020-2122;
 }
+
 html {
-	font-family:sans-serif;
-	-ms-text-size-adjust:100%;
-	-webkit-text-size-adjust:100%;
+	-ms-text-size-adjust: 100%;
+	-webkit-text-size-adjust: 100%;
+	-webkit-tap-highlight-color: rgba(0,0,0,0);
+	-webkit-text-size-adjust: 100%;
+	-ms-text-size-adjust: 100%;
+	border: 0;
+	font-family: sans-serif;
+	font-size: 100%;
+	font-family: "Source Sans Pro", Helvetica, sans-serif;
+	height: 100%;
+	margin: 0;
+	overflow-y: scroll;
+	padding: 0;
+	vertical-align: baseline;
 }
+
 body {
-	margin:0;
+	background: rgba(44,62,80,0.92);
+	background: #fff;
+	border: 0;
+	color: #141412;
+	font-size: 14px;
+	font-family: Georgia, "Times New Roman", Times, serif;
+	height: 100%;
+	line-height: 1.5;
+	margin: 0;
+	padding: 0;
+	vertical-align: baseline;
 }
-main, nav, section {
-	display:block;
+
+main {
+	display: block;
+	margin-right: auto;
+	margin-left: auto;
+	min-height: 700px;
+	padding-left: 15px;
+	padding-right: 15px;
+	padding-left: 0em;
+	padding-right: 0em;
+	width: 100%;
 }
+
+nav {
+	border: 0;
+	display: block;
+	font-size: 100%;
+	font: inherit;
+	margin: 0;
+	padding: 0;
+	vertical-align: baseline;
+}
+
+section {
+	border: 0;
+	display: block;
+	font-size: 100%;
+	font: inherit;
+	margin-left: -15px;
+	margin-right: -15px;
+	margin: 0;
+	padding: 0;
+	vertical-align: baseline;
+}
+
 a {
-	background:transparent;
+	-webkit-transition: all 0.5s ease;
+	-moz-transition: all 0.5s ease;
+	-o-transition: all 0.5s ease;
+	-ms-transition: all 0.5s ease;
+	background: transparent;
+	border: 0;
+	color: #428bca;
+	color: rgba(74,92,110,0.92);
+	color: #eb3b45;
+	font-size: 100%;
+	font: inherit;
+	margin: 0;
+	padding: 0;
+	text-decoration: none;
+	transition: all 0.5s ease;
+	vertical-align: baseline;
 }
-a:active, a:hover {
-	outline:0;
+
+a:active {
+	color: #000000;
+	outline: 0;
+	outline: 0;
 }
+
+a:hover {
+	-webkit-transition: all 0.5s ease;
+	-moz-transition: all 0.5s ease;
+	-o-transition: all 0.5s ease;
+	-ms-transition: all 0.5s ease;
+	color: #2a6496;
+	color: #fff;
+	color: #000000;
+	outline: 0;
+	outline: 0;
+	text-decoration: underline;
+	text-decoration: none;
+	text-decoration: none;
+	transition: all 0.5s ease;
+}
+
 img {
-	border:0;
+	-ms-interpolation-mode: bicubic;
+	border: 0;
+	border: 0;
+	border: 0;
+	display: block;
+	font-size: 100%;
+	font: inherit;
+	height: auto;
+	margin: 0 auto;
+	margin: 0;
+	max-width: 100%;
+	max-width: 100%;
+	padding: 0;
+	vertical-align: middle;
+	vertical-align: baseline;
+	vertical-align: middle;
 }
-button, input {
-	color:inherit;
-	font:inherit;
-	margin:0;
-}
+
 button {
-	overflow:visible;
+	-webkit-appearance: button;
+	-webkit-appearance: button;
+	border: none;
+	border-radius: 2px;
+	color: inherit;
+	color: #fff;
+	cursor: pointer;
+	cursor: pointer;
+	font: inherit;
+	font-family: inherit;
+	font-size: inherit;
+	font-family: "Source Sans Pro", Helvetica, sans-serif;
+	font-size: 100%;
+	line-height: inherit;
+	line-height: normal;
+	margin: 0;
+	margin: 0;
+	max-width: 100%;
+	overflow: visible;
+	text-transform: none;
+	vertical-align: baseline;
 }
-button {
-	text-transform:none;
-}
-button, input[type="submit"] {
-	-webkit-appearance:button;
-	cursor:pointer;
-}
-button::-moz-focus-inner, input::-moz-focus-inner {
-	border:0;
-	padding:0;
-}
+
 input {
-	line-height:normal;
+	color: inherit;
+	font: inherit;
+	font-family: inherit;
+	font-size: inherit;
+	font-family: "Source Sans Pro", Helvetica, sans-serif;
+	font-size: 100%;
+	line-height: normal;
+	line-height: inherit;
+	line-height: normal;
+	margin: 0;
+	margin: 0;
+	max-width: 100%;
+	vertical-align: baseline;
 }
+
+input[type="submit"] {
+	-webkit-appearance: button;
+	-webkit-appearance: button;
+	border: none;
+	border-radius: 2px;
+	color: #fff;
+	cursor: pointer;
+	cursor: pointer;
+}
+
+button::-moz-focus-inner {
+	border: 0;
+	border: 0;
+	padding: 0;
+	padding: 0;
+}
+
+input::-moz-focus-inner {
+	border: 0;
+	border: 0;
+	padding: 0;
+	padding: 0;
+}
+
 @media print {
 	* {
-		text-shadow:none !important;
-		color:#000 !important;
-		background:transparent !important;
-		box-shadow:none !important;
+		text-shadow: none !important;
+		color: #000 !important;
+		background: transparent !important;
+		box-shadow: none !important;
 	}
-	a, a:visited {
-		text-decoration:underline;
+	a {
+		text-decoration: underline;
+	}
+	a:visited {
+		text-decoration: underline;
 	}
 	a[href]:after {
-		content:" (" attr(href) ")";
+		content: " (" attr(href) ")";
 	}
 	a[href^="#"]:after {
-		content:"";
+		content: "";
 	}
 	img {
-		page-break-inside:avoid;
+		max-width: 100% !important;
+		page-break-inside: avoid;
 	}
-	img {
-		max-width:100% !important;
+	p {
+		orphans: 3;
+		widows: 3;
 	}
-	p, h2, h3 {
-		orphans:3;
-		widows:3;
+	h2 {
+		orphans: 3;
+		page-break-after: avoid;
+		widows: 3;
 	}
-	h2, h3 {
-		page-break-after:avoid;
+	h3 {
+		orphans: 3;
+		page-break-after: avoid;
+		widows: 3;
 	}
 }
+
 * {
-	-webkit-box-sizing:border-box;
-	-moz-box-sizing:border-box;
-	box-sizing:border-box;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	-o-box-sizing: border-box;
+	-ms-box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
+	box-sizing: border-box;
+	box-sizing: border-box;
 }
-*:before, *:after {
-	-webkit-box-sizing:border-box;
-	-moz-box-sizing:border-box;
-	box-sizing:border-box;
+
+*:before {
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
 }
-html {
-	font-size:62.5%;
-	-webkit-tap-highlight-color:rgba(0,0,0,0);
+
+*:after {
+	-webkit-box-sizing: border-box;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
 }
-body {
-	font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;
-	font-size:14px;
-	line-height:1.428571429;
-	color:#333333;
-	background-color:white;
-}
-input, button {
-	font-family:inherit;
-	font-size:inherit;
-	line-height:inherit;
-}
-a {
-	color:#428bca;
-	text-decoration:none;
-}
-a:hover, a:focus {
-	color:#2a6496;
-	text-decoration:underline;
-}
+
 a:focus {
-	outline:thin dotted;
-	outline:5px auto -webkit-focus-ring-color;
-	outline-offset:-2px;
+	color: #2a6496;
+	outline: thin dotted;
+	outline: 5px auto -webkit-focus-ring-color;
+	outline-offset: -2px;
+	outline: thin dotted;
+	text-decoration: underline;
+	text-decoration: none;
 }
-img {
-	vertical-align:middle;
-}
-img {
-	display:block;
-	max-width:100%;
-	height:auto;
-}
-h2, h3, h4 {
-	font-family:inherit;
-	font-weight:500;
-	line-height:1.1;
-	color:inherit;
-}
-h2, h3 {
-	margin-top:20px;
-	margin-bottom:10px;
-}
-h4 {
-	margin-top:10px;
-	margin-bottom:10px;
-}
+
 h2 {
-	font-size:30px;
+	border: 0;
+	clear: both;
+	color: inherit;
+	font-family: inherit;
+	font-weight: 500;
+	font-size: 30px;
+	font-weight: normal;
+	font-weight: 400;
+	font-size: 36px;
+	font-size: 100%;
+	font: inherit;
+	font-family: TradeGothic, Impact, "Source Sans Pro", sans-serif;
+	font-weight: 100;
+	font-size: 30px;
+	line-height: 1.1;
+	line-height: 1.3;
+	margin-top: 20px;
+	margin-bottom: 10px;
+	margin-top: 24px;
+	margin-bottom: 8px;
+	margin: 0;
+	margin: 24px 0 10px;
+	padding: 0;
+	text-transform: uppercase;
+	text-transform: uppercase;
+	vertical-align: baseline;
 }
+
 h3 {
-	font-size:24px;
+	border: 0;
+	clear: both;
+	color: inherit;
+	font-family: inherit;
+	font-weight: 500;
+	font-size: 24px;
+	font-weight: normal;
+	font-weight: 400;
+	font-size: 24px;
+	font-size: 100%;
+	font: inherit;
+	font-family: TradeGothic, Impact, "Source Sans Pro", sans-serif;
+	font-weight: 100;
+	font-size: 22px;
+	line-height: 1.1;
+	line-height: 1.3;
+	margin-top: 20px;
+	margin-bottom: 10px;
+	margin-top: 16px;
+	margin-bottom: 8px;
+	margin: 0;
+	margin: 21px 0 10px;
+	padding: 0;
+	text-transform: uppercase;
+	vertical-align: baseline;
 }
+
 h4 {
-	font-size:18px;
+	border: 0;
+	clear: both;
+	color: inherit;
+	font-family: inherit;
+	font-weight: 500;
+	font-size: 18px;
+	font-weight: bold;
+	font-weight: 700;
+	font-size: 18px;
+	font-size: 100%;
+	font: inherit;
+	font-family: TradeGothic, Impact, "Source Sans Pro", sans-serif;
+	font-weight: 100;
+	font-size: 20px;
+	line-height: 1.1;
+	line-height: 1.3;
+	margin-top: 10px;
+	margin-bottom: 10px;
+	margin: 0;
+	margin: 14px 0;
+	padding: 0;
+	text-transform: uppercase;
+	vertical-align: baseline;
 }
+
 p {
-	margin:0 0 10px;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	font-size: 1.2em;
+	line-height: 2.0em;
+	margin: 0 0 10px;
+	margin: 0;
+	margin: 0 0 24px;
+	padding: 0;
+	vertical-align: baseline;
 }
+
 ul {
-	margin-top:0;
-	margin-bottom:10px;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	list-style: none;
+	list-style: none;
+	margin-top: 0;
+	margin-bottom: 10px;
+	margin: 0;
+	margin: 10px 0 25px;
+	padding: 0;
+	padding: 0 0 0 40px;
+	vertical-align: baseline;
 }
+
 ul ul {
-	margin-bottom:0;
+	margin-bottom: 0;
 }
-.container, .plank .section-container {
-	margin-right:auto;
-	margin-left:auto;
-	padding-left:15px;
-	padding-right:15px;
+
+.container {
+	margin-right: auto;
+	margin-left: auto;
+	padding-left: 15px;
+	padding-right: 15px;
 }
-.container:before, .plank .section-container:before, .container:after, .plank .section-container:after {
-	content:" ";
-	display:table;
+
+.plank .section-container {
+	margin-right: auto;
+	margin-left: auto;
+	padding-left: 15px;
+	padding-right: 15px;
 }
-.container:after, .plank .section-container:after {
-	clear:both;
+
+.container:before {
+	content: " ";
+	display: table;
 }
+
+.plank .section-container:before {
+	content: " ";
+	display: table;
+}
+
+.container:after {
+	clear: both;
+	content: " ";
+	display: table;
+}
+
+.plank .section-container:after {
+	clear: both;
+	content: " ";
+	display: table;
+}
+
 @media (min-width: 768px) {
-	.container, .plank .section-container {
-		width:750px;
+	.container {
+		width: 750px;
+	}
+	.plank .section-container {
+		width: 750px;
 	}
 }
+
 @media (min-width: 992px) {
-	.container, .plank .section-container {
-		width:970px;
+	.container {
+		width: 970px;
+	}
+	.plank .section-container {
+		width: 970px;
 	}
 }
+
 @media (min-width: 1200px) {
-	.container, .plank .section-container {
-		width:1170px;
+	.container {
+		width: 1170px;
+	}
+	.plank .section-container {
+		width: 1170px;
 	}
 }
-main {
-	margin-right:auto;
-	margin-left:auto;
-	padding-left:15px;
-	padding-right:15px;
+
+main:before {
+	content: " ";
+	display: table;
 }
-main:before, main:after {
-	content:" ";
-	display:table;
-}
+
 main:after {
-	clear:both;
+	clear: both;
+	content: " ";
+	display: table;
 }
-section {
-	margin-left:-15px;
-	margin-right:-15px;
+
+section:before {
+	content: " ";
+	display: table;
 }
-section:before, section:after {
-	content:" ";
-	display:table;
-}
+
 section:after {
-	clear:both;
+	clear: both;
+	content: " ";
+	display: table;
 }
+
 .col-md-4 {
-	position:relative;
-	min-height:1px;
-	padding-left:15px;
-	padding-right:15px;
+	position: relative;
+	min-height: 1px;
+	padding-left: 15px;
+	padding-right: 15px;
 }
+
 @media (min-width: 992px) {
 	.col-md-4 {
-		float:left;
-	}
-	.col-md-4 {
-		width:33.3333333333%;
+		float: left;
+		width: 33.3333333333%;
 	}
 	.col-md-offset-4 {
-		margin-left:33.3333333333%;
+		margin-left: 33.3333333333%;
 	}
 }
+
 label {
-	display:inline-block;
-	max-width:100%;
-	margin-bottom:5px;
-	font-weight:bold;
+	border: 0;
+	display: inline-block;
+	font-weight: bold;
+	font-size: 100%;
+	font: inherit;
+	margin-bottom: 5px;
+	margin: 0;
+	max-width: 100%;
+	padding: 0;
+	vertical-align: baseline;
 }
+
 .form-control {
-	display:block;
-	width:100%;
-	height:34px;
-	padding:6px 12px;
-	font-size:14px;
-	line-height:1.428571429;
-	color:#555555;
-	background-color:white;
-	background-image:none;
-	border:1px solid #cccccc;
-	border-radius:4px;
-	-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);
-	box-shadow:inset 0 1px 1px rgba(0,0,0,0.075);
-	-webkit-transition:border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
-	-o-transition:border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
-	transition:border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+	display: block;
+	width: 100%;
+	height: 34px;
+	padding: 6px 12px;
+	font-size: 14px;
+	line-height: 1.428571429;
+	color: #555555;
+	background-color: white;
+	background-image: none;
+	border: 1px solid #cccccc;
+	border-radius: 4px;
+	-webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+	box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+	-webkit-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+	-o-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+	transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
 }
+
 .form-control:focus {
-	border-color:#66afe9;
-	outline:0;
-	-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6);
-	box-shadow:inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6);
+	border-color: #66afe9;
+	outline: 0;
+	-webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6);
+	box-shadow: inset 0 1px 1px rgba(0,0,0,0.075),0 0 8px rgba(102,175,233,0.6);
 }
+
 .form-control::-moz-placeholder {
-	color:#999999;
-	opacity:1;
+	color: #999999;
+	opacity: 1;
 }
+
 .form-control:-ms-input-placeholder {
-	color:#999999;
+	color: #999999;
 }
+
 .form-control::-webkit-input-placeholder {
-	color:#999999;
+	color: #999999;
 }
-.btn, .button-primary {
-	display:inline-block;
-	margin-bottom:0;
-	font-weight:normal;
-	text-align:center;
-	vertical-align:middle;
-	cursor:pointer;
-	background-image:none;
-	border:1px solid transparent;
-	white-space:nowrap;
-	padding:6px 12px;
-	font-size:14px;
-	line-height:1.428571429;
-	border-radius:4px;
-	-webkit-user-select:none;
-	-moz-user-select:none;
-	-ms-user-select:none;
-	user-select:none;
+
+.btn {
+	display: inline-block;
+	margin-bottom: 0;
+	font-weight: normal;
+	text-align: center;
+	vertical-align: middle;
+	cursor: pointer;
+	background-image: none;
+	border: 1px solid transparent;
+	white-space: nowrap;
+	padding: 6px 12px;
+	font-size: 14px;
+	line-height: 1.428571429;
+	border-radius: 4px;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
 }
-.btn:focus, .button-primary:focus, .btn:active:focus, .button-primary:active:focus {
-	outline:thin dotted;
-	outline:5px auto -webkit-focus-ring-color;
-	outline-offset:-2px;
-}
-.btn:hover, .button-primary:hover, .btn:focus, .button-primary:focus {
-	color:#333333;
-	text-decoration:none;
-}
-.btn:active, .button-primary:active {
-	outline:0;
-	background-image:none;
-	-webkit-box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);
-	box-shadow:inset 0 3px 5px rgba(0,0,0,0.125);
-}
-.btn-default {
-	color:#333333;
-	background-color:white;
-	border-color:#cccccc;
-}
-.btn-default:hover, .btn-default:focus, .btn-default:active {
-	color:#333333;
-	background-color:#e6e6e6;
-	border-color:#adadad;
-}
-.btn-default:active {
-	background-image:none;
-}
+
 .button-primary {
-	color:white;
-	background-color:#428bca;
-	border-color:#357ebd;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	-webkit-border-radius: 5px;
+	-moz-border-radius: 5px;
+	background-image: none;
+	background-color: #428bca;
+	background-color: #eb3b45;
+	background: #000000;
+	background: #eb3b45;
+	border: 1px solid transparent;
+	border-radius: 4px;
+	border-color: #357ebd;
+	border-radius: 6px;
+	border-color: white !important;
+	border-radius: 5px;
+	color: white;
+	color: #fff !important;
+	color: #fff !important;
+	cursor: pointer;
+	cursor: pointer;
+	display: inline-block;
+	display: inline-block;
+	font-weight: normal;
+	font-size: 14px;
+	font-size: 18px;
+	font-family: TradeGothic, Impact, sans-serif;
+	font-size: 21px;
+	font-weight: 400;
+	letter-spacing: 1px;
+	line-height: 1.428571429;
+	line-height: 1.33;
+	line-height: 1.333em;
+	margin-bottom: 0;
+	margin-left: 0;
+	margin-right: 0;
+	margin-top: 0;
+	padding: 6px 12px;
+	padding: 10px 16px;
+	padding-bottom: 10px;
+	padding-left: 50px;
+	padding-right: 50px;
+	padding-top: 10px;
+	text-align: center;
+	text-align: center;
+	text-transform: uppercase;
+	text-shadow: none;
+	transition: all 0.5s ease 0s;
+	user-select: none;
+	vertical-align: middle;
+	vertical-align: middle;
+	white-space: nowrap;
 }
-.button-primary:hover, .button-primary:focus, .button-primary:active {
-	color:white;
-	background-color:#3071a9;
-	border-color:#285e8e;
+
+.btn:focus {
+	color: #333333;
+	outline: thin dotted;
+	outline: 5px auto -webkit-focus-ring-color;
+	outline-offset: -2px;
+	text-decoration: none;
 }
+
+.button-primary:focus {
+	background-color: #3071a9;
+	border-color: #285e8e;
+	color: #333333;
+	color: white;
+	outline: thin dotted;
+	outline: 5px auto -webkit-focus-ring-color;
+	outline-offset: -2px;
+	text-decoration: none;
+}
+
+.btn:active:focus {
+	outline: thin dotted;
+	outline: 5px auto -webkit-focus-ring-color;
+	outline-offset: -2px;
+}
+
+.button-primary:active:focus {
+	outline: thin dotted;
+	outline: 5px auto -webkit-focus-ring-color;
+	outline-offset: -2px;
+}
+
+.btn:hover {
+	color: #333333;
+	text-decoration: none;
+}
+
+.button-primary:hover {
+	background-color: #3071a9;
+	background: #000;
+	border-color: #285e8e;
+	color: #333333;
+	color: white;
+	color: #fff !important;
+	text-decoration: none;
+}
+
+.btn:active {
+	outline: 0;
+	background-image: none;
+	-webkit-box-shadow: inset 0 3px 5px rgba(0,0,0,0.125);
+	box-shadow: inset 0 3px 5px rgba(0,0,0,0.125);
+}
+
 .button-primary:active {
-	background-image:none;
+	-webkit-box-shadow: inset 0 3px 5px rgba(0,0,0,0.125);
+	background-image: none;
+	background-color: #3071a9;
+	background-image: none;
+	border-color: #285e8e;
+	box-shadow: inset 0 3px 5px rgba(0,0,0,0.125);
+	color: white;
+	outline: 0;
 }
-.button-primary {
-	padding:10px 16px;
-	font-size:18px;
-	line-height:1.33;
-	border-radius:6px;
+
+.btn-default {
+	color: #333333;
+	background-color: white;
+	border-color: #cccccc;
 }
+
+.btn-default:hover {
+	color: #333333;
+	background-color: #e6e6e6;
+	border-color: #adadad;
+}
+
+.btn-default:focus {
+	color: #333333;
+	background-color: #e6e6e6;
+	border-color: #adadad;
+}
+
+.btn-default:active {
+	background-color: #e6e6e6;
+	background-image: none;
+	border-color: #adadad;
+	color: #333333;
+}
+
 .fade {
-	opacity:0;
-	-webkit-transition:opacity 0.15s linear;
-	-o-transition:opacity 0.15s linear;
-	transition:opacity 0.15s linear;
+	opacity: 0;
+	-webkit-transition: opacity 0.15s linear;
+	-o-transition: opacity 0.15s linear;
+	transition: opacity 0.15s linear;
 }
+
 .close {
-	float:right;
-	font-size:21px;
-	font-weight:bold;
-	line-height:1;
-	color:black;
-	text-shadow:0 1px 0 white;
-	opacity:0.2;
-	filter:alpha(opacity=20);
+	-webkit-border-radius: 12px;
+	-moz-border-radius: 12px;
+	-moz-box-shadow: 1px 1px 3px #000;
+	-webkit-box-shadow: 1px 1px 3px #000;
+	background: #eb3b45;
+	border-radius: 12px;
+	box-shadow: 1px 1px 3px #000;
+	color: black;
+	color: #FFFFFF !important;
+	filter: alpha(opacity=20);
+	float: right;
+	font-size: 21px;
+	font-weight: bold;
+	font-weight: bold;
+	line-height: 1;
+	line-height: 25px;
+	opacity: 0.2;
+	position: absolute;
+	right: -12px;
+	text-shadow: 0 1px 0 white;
+	text-align: center;
+	text-decoration: none;
+	top: -10px;
+	width: 24px;
 }
-.close:hover, .close:focus {
-	color:black;
-	text-decoration:none;
-	cursor:pointer;
-	opacity:0.5;
-	filter:alpha(opacity=50);
+
+.close:hover {
+	background: #000;
+	color: black;
+	cursor: pointer;
+	filter: alpha(opacity=50);
+	opacity: 0.5;
+	text-decoration: none;
 }
+
+.close:focus {
+	color: black;
+	text-decoration: none;
+	cursor: pointer;
+	opacity: 0.5;
+	filter: alpha(opacity=50);
+}
+
 button.close {
-	padding:0;
-	cursor:pointer;
-	background:transparent;
-	border:0;
-	-webkit-appearance:none;
+	padding: 0;
+	cursor: pointer;
+	background: transparent;
+	border: 0;
+	-webkit-appearance: none;
 }
+
 .modal {
-	display:none;
-	overflow:auto;
-	overflow-y:scroll;
-	position:fixed;
-	top:0;
-	right:0;
-	bottom:0;
-	left:0;
-	z-index:1050;
-	-webkit-overflow-scrolling:touch;
-	outline:0;
+	display: none;
+	overflow: auto;
+	overflow-y: scroll;
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	z-index: 1050;
+	-webkit-overflow-scrolling: touch;
+	outline: 0;
 }
+
 .modal.fade .modal-dialog {
-	-webkit-transform:translate(0, -25%);
-	-ms-transform:translate(0, -25%);
-	-o-transform:translate(0, -25%);
-	transform:translate(0, -25%);
-	-webkit-transition:-webkit-transform 0.3s ease-out;
-	-moz-transition:-moz-transform 0.3s ease-out;
-	-o-transition:-o-transform 0.3s ease-out;
-	transition:transform 0.3s ease-out;
+	-webkit-transform: translate(0, -25%);
+	-ms-transform: translate(0, -25%);
+	-o-transform: translate(0, -25%);
+	transform: translate(0, -25%);
+	-webkit-transition: -webkit-transform 0.3s ease-out;
+	-moz-transition: -moz-transform 0.3s ease-out;
+	-o-transition: -o-transform 0.3s ease-out;
+	transition: transform 0.3s ease-out;
 }
+
 .modal-dialog {
-	position:relative;
-	width:auto;
-	margin:10px;
+	position: relative;
+	width: auto;
+	margin: 10px;
 }
+
 .modal-content {
-	position:relative;
-	background-color:white;
-	border:1px solid #999999;
-	border:1px solid rgba(0,0,0,0.2);
-	border-radius:6px;
-	-webkit-box-shadow:0 3px 9px rgba(0,0,0,0.5);
-	box-shadow:0 3px 9px rgba(0,0,0,0.5);
-	background-clip:padding-box;
-	outline:0;
+	position: relative;
+	background-color: white;
+	border: 1px solid #999999;
+	border: 1px solid rgba(0,0,0,0.2);
+	border-radius: 6px;
+	-webkit-box-shadow: 0 3px 9px rgba(0,0,0,0.5);
+	box-shadow: 0 3px 9px rgba(0,0,0,0.5);
+	background-clip: padding-box;
+	outline: 0;
 }
+
 .modal-header {
-	padding:15px;
-	border-bottom:1px solid #e5e5e5;
-	min-height:16.428571429px;
+	padding: 15px;
+	border-bottom: 1px solid #e5e5e5;
+	min-height: 16.428571429px;
 }
+
 .modal-header .close {
-	margin-top:-2px;
+	margin-top: -2px;
 }
+
 .modal-title {
-	margin:0;
-	line-height:1.428571429;
+	margin: 0;
+	line-height: 1.428571429;
 }
+
 .modal-body {
-	position:relative;
-	padding:15px;
+	position: relative;
+	padding: 15px;
 }
+
 .modal-footer {
-	padding:15px;
-	text-align:right;
-	border-top:1px solid #e5e5e5;
+	padding: 15px;
+	text-align: right;
+	border-top: 1px solid #e5e5e5;
 }
-.modal-footer:before, .modal-footer:after {
-	content:" ";
-	display:table;
+
+.modal-footer:before {
+	content: " ";
+	display: table;
 }
+
 .modal-footer:after {
-	clear:both;
+	clear: both;
+	content: " ";
+	display: table;
 }
+
 @media (min-width: 768px) {
 	.modal-dialog {
-		width:600px;
-		margin:30px auto;
+		width: 600px;
+		margin: 30px auto;
 	}
 	.modal-content {
-		-webkit-box-shadow:0 5px 15px rgba(0,0,0,0.5);
-		box-shadow:0 5px 15px rgba(0,0,0,0.5);
+		-webkit-box-shadow: 0 5px 15px rgba(0,0,0,0.5);
+		box-shadow: 0 5px 15px rgba(0,0,0,0.5);
 	}
 	.modal-sm {
-		width:300px;
+		width: 300px;
 	}
 }
-body {
-	color:#333333;
-	font-family:"Open Sans", sans-serif;
-	font-size:14px;
-}
-h2 {
-	text-transform:uppercase;
-}
-h2, h3 {
-	font-weight:normal;
-	font-weight:400;
-}
-h4 {
-	font-weight:bold;
-	font-weight:700;
-}
-h4 {
-	font-size:18px;
-}
-h3 {
-	font-size:24px;
-	margin-top:16px;
-	margin-bottom:8px;
-}
-h2 {
-	margin-top:24px;
-	margin-bottom:8px;
-}
-h2 {
-	font-size:36px;
-}
+
 @media (max-width: 991px) {
 	h2 {
-		font-size:24px;
+		font-size: 24px;
 	}
 }
-.button-primary {
-	background-color:#eb3b45;
-	border-color:white !important;
-}
+
 .clear {
-	clear:both;
+	clear: both;
+	clear: both;
 }
-html, body {
-	height:100%;
-}
-img {
-	margin:0 auto;
-}
-a {
-	text-decoration:none;
-}
-a:hover, a:focus {
-	text-decoration:none;
-}
-main {
-	width:100%;
-	padding-left:0em;
-	padding-right:0em;
-	min-height:700px;
-}
+
 *:target::before {
-	height:45px;
-	display:block;
-	content:'\a0';
+	height: 45px;
+	display: block;
+	content: '\a0';
 }
+
 .public-container {
-	padding:0px;
+	padding: 0px;
 }
+
 .plank {
-	width:100%;
+	color: #333333;
+	width: 100%;
 }
+
 .plank .section-container>section>div:not(.no-pad) {
-	padding:2.25em 0.938em 1.5em 0.938em;
+	padding: 2.25em 0.938em 1.5em 0.938em;
 }
-.plank {
-	color:#333333;
-}
+
 .plank.plain-md {
-	background-color:#e6e6e6;
+	background-color: #e6e6e6;
 }
+
 .plank.plain-md a {
-	color:#0071bc;
+	color: #0071bc;
 }
+
 .plank.plain-md .section-container {
-	background-color:#f2f2f2;
+	background-color: #f2f2f2;
 }
-html, body, div, span, h2, h3, h4, p, a, img, ul, li, form, label, nav, section {
-	margin:0;
-	padding:0;
-	border:0;
-	font-size:100%;
-	font:inherit;
-	vertical-align:baseline;
+
+div {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-nav, section {
-	display:block;
+
+span {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-body {
-	line-height:1;
+
+li {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	vertical-align: baseline;
 }
-ul {
-	list-style:none;
+
+form {
+	border: 0;
+	font-size: 100%;
+	font: inherit;
+	margin: 0;
+	margin: 0;
+	padding: 0;
+	vertical-align: baseline;
 }
-body {
-	background:rgba(44,62,80,0.92);
-	color:#fff;
-	font-size:14px;
-	font-family:'Open Sans', sans-serif, 'trebuhet ms',HelveticaNeue, arial;
-	height:100%;
-	line-height:20px;
-}
-* {
-	-webkit-box-sizing:border-box;
-	-moz-box-sizing:border-box;
-	-o-box-sizing:border-box;
-	-ms-box-sizing:border-box;
-	box-sizing:border-box;
-}
-p {
-	line-height:2.0em;
-}
-a {
-	text-decoration:none;
-	color:rgba(74,92,110,0.92);
-}
-a:hover {
-	color:#fff;
-}
-img {
-	max-width:100%;
-}
-a, a:hover {
-	-webkit-transition:all 0.5s ease;
-	-moz-transition:all 0.5s ease;
-	-o-transition:all 0.5s ease;
-	-ms-transition:all 0.5s ease;
-	transition:all 0.5s ease;
-}
-body {
-	background:#fff;
-	font-family:Georgia, "Times New Roman", Times, serif;
-}
-p {
-	margin: 0 0 24px;
-	font-size:1.2em;
-}
-a {
-	color:#eb3b45;
-}
+
 .upperheader_red {
-	background:#eb3b45;
+	background: #eb3b45;
 	padding-bottom: 8px;
 	padding-left: 0;
 	padding-right: 0;
 	padding-top: 8px;
 }
+
 .upperheader_red h4 {
-	color:#fff;
-	text-align:right;
-	margin:0;
-	font-size:1em;
+	color: #fff;
+	text-align: right;
+	margin: 0;
+	font-size: 1em;
 }
+
 .upperheader_red .container {
-	max-width:1000px;
+	max-width: 1000px;
 	margin: 0 auto;
-	padding-right:1.3em;
-	padding-left:1.3em;
+	padding-right: 1.3em;
+	padding-left: 1.3em;
 }
+
 .upperheader_red .social a {
 	display: inline-block;
 	margin-left: 4px;
 	vertical-align: sub;
 }
+
 .upperheader_red a.facebook_icon {
-	background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAASCAMAAABVab95AAAAXVBMVEX///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8/beDHAAAAHnRSTlMAAQMFCAsMIS8xSElMT2CVl6iqrLC+4+vs8PH0/P0OEXnGAAAAUklEQVQIma3LWRKAIAwD0LpvCFbchd7/mAYd8QLmJ286DRHSm9HaLGiQkByqJLJDT1qnoAIV3YkstgM89zWh8hnJgqvzgHfz+9t+s9/YMHONvgAQqAmx4EohrQAAAABJRU5ErkJggg==) no-repeat center center;
-	width:18px;
-	height:18px;
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAASCAMAAABVab95AAAAXVBMVEX///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8/beDHAAAAHnRSTlMAAQMFCAsMIS8xSElMT2CVl6iqrLC+4+vs8PH0/P0OEXnGAAAAUklEQVQIma3LWRKAIAwD0LpvCFbchd7/mAYd8QLmJ286DRHSm9HaLGiQkByqJLJDT1qnoAIV3YkstgM89zWh8hnJgqvzgHfz+9t+s9/YMHONvgAQqAmx4EohrQAAAABJRU5ErkJggg==) no-repeat center center;
+	width: 18px;
+	height: 18px;
 }
+
 .upperheader_red a.ig_icon {
-	background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAMAAAC6V+0/AAABC1BMVEX///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////+/RJMjAAAAWHRSTlMAAQMEBQYHCQwNFRYbHCYqKywvMDI0NzpFR0xRUlNYWVxhZ2xwcnWEhoiJi42Oj5OUlZidnqSlrK+wsrS2t7i5vL7Fy8zQ1dfY3t/j6Onq6+zz9/j6+/3+BwFCSAAAANNJREFUGJVjYMABeCWl4ECSGyKmHRaBBELUQGKKSCJ+dnauERJAQXskQWsGBrkIE6CgM7qgBVDQBUnQWVpWL8ISIeigpAzVAxYMMjV1jzAEspgsI1xMzSCCPgwMjsGcIIfwRRgzMMMF3bzALmYMt0YStA3lAgmKRBggCSpEmLMwMHA4RYgjCTJaRXho6npH6DMgCTKwagRGRPirMsIEnX3AlrAJCTCDaGawj2xCeZDDUTTCCEjKRHhqqcOBjm+YGEhOJRA5PAPkITrYBYXhgB/oNAYAy6U/Q/A3iDYAAAAASUVORK5CYII=) no-repeat center center;
-	width:18px;
-	height:18px;
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAMAAAC6V+0/AAABC1BMVEX///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////+/RJMjAAAAWHRSTlMAAQMEBQYHCQwNFRYbHCYqKywvMDI0NzpFR0xRUlNYWVxhZ2xwcnWEhoiJi42Oj5OUlZidnqSlrK+wsrS2t7i5vL7Fy8zQ1dfY3t/j6Onq6+zz9/j6+/3+BwFCSAAAANNJREFUGJVjYMABeCWl4ECSGyKmHRaBBELUQGKKSCJ+dnauERJAQXskQWsGBrkIE6CgM7qgBVDQBUnQWVpWL8ISIeigpAzVAxYMMjV1jzAEspgsI1xMzSCCPgwMjsGcIIfwRRgzMMMF3bzALmYMt0YStA3lAgmKRBggCSpEmLMwMHA4RYgjCTJaRXho6npH6DMgCTKwagRGRPirMsIEnX3AlrAJCTCDaGawj2xCeZDDUTTCCEjKRHhqqcOBjm+YGEhOJRA5PAPkITrYBYXhgB/oNAYAy6U/Q/A3iDYAAAAASUVORK5CYII=) no-repeat center center;
+	width: 18px;
+	height: 18px;
 }
+
 .upperheader_red a.twitter_icon {
-	background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAQAAACI04Q8AAAAzUlEQVQokWP4z4AD8iDY2BXY/r/6f9V/NVRFuv9b/yvAlYj+f/P///8v/5f8F0FWxPr/7P+//9f/NwPzpv6HgUv/OZGtK/v/Cyy8Gmjit/8IUIisKO7/H6jwh//I4O7/zv9+MEWMQBf8+48NbP/vivBR8f97WJQd+W/znwXZ4+VYzAmGuIkdrkjq/0k0JXtgQaAM9IHVf63/gf+3oik5918YEU7qwFBCB3//z0REDIRi/h8B9MUXqIJb//v/ayJHE7LDGf+L/5eBhDEqBABnBWaorqWnYQAAAABJRU5ErkJggg==) no-repeat center center;
-	width:18px;
-	height:18px;
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAAOCAQAAACI04Q8AAAAzUlEQVQokWP4z4AD8iDY2BXY/r/6f9V/NVRFuv9b/yvAlYj+f/P///8v/5f8F0FWxPr/7P+//9f/NwPzpv6HgUv/OZGtK/v/Cyy8Gmjit/8IUIisKO7/H6jwh//I4O7/zv9+MEWMQBf8+48NbP/vivBR8f97WJQd+W/znwXZ4+VYzAmGuIkdrkjq/0k0JXtgQaAM9IHVf63/gf+3oik5918YEU7qwFBCB3//z0REDIRi/h8B9MUXqIJb//v/ayJHE7LDGf+L/5eBhDEqBABnBWaorqWnYQAAAABJRU5ErkJggg==) no-repeat center center;
+	width: 18px;
+	height: 18px;
 }
+
 .upperheader_red a.mail_icon {
-	background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAOCAQAAACFzfR7AAAA60lEQVQokY2Qv0uCYRDHjxAkRUlIEEIQ00kw/AsEiSb7Y/Q/EHQTh0gXhYbAKLCtQKem1uptaVBweqfMFifDT/dkvvmL9HvLfe8+x3P3CFtKGG3FjYQjehuxLkmhQZD7f7E7fJyJJh32KDBZC02046dtdjSyCHPK5wo2JEucN5PKb8kmRYzXBczSSoaPqRGnXMWFlyvHN9Xt8DCzM7CFm1ttesgz1sgpds2NnvE0D3bYVcjomQhpjSgvP/6S/b8dH3XuwnnynWNOGDi+zgF9A1oEqC0c8aUxr3MOsYUQlZVvWVaZhFDaiBkVvwE8xABK59IZmQAAAABJRU5ErkJggg==) no-repeat center center;
-	width:18px;
-	height:18px;
+	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAOCAQAAACFzfR7AAAA60lEQVQokY2Qv0uCYRDHjxAkRUlIEEIQ00kw/AsEiSb7Y/Q/EHQTh0gXhYbAKLCtQKem1uptaVBweqfMFifDT/dkvvmL9HvLfe8+x3P3CFtKGG3FjYQjehuxLkmhQZD7f7E7fJyJJh32KDBZC02046dtdjSyCHPK5wo2JEucN5PKb8kmRYzXBczSSoaPqRGnXMWFlyvHN9Xt8DCzM7CFm1ttesgz1sgpds2NnvE0D3bYVcjomQhpjSgvP/6S/b8dH3XuwnnynWNOGDi+zgF9A1oEqC0c8aUxr3MOsYUQlZVvWVaZhFDaiBkVvwE8xABK59IZmQAAAABJRU5ErkJggg==) no-repeat center center;
+	width: 18px;
+	height: 18px;
 }
+
 #topheader {
 	background-color: #ffffff;
 	width: 100%;
-	height:60px;
-	position:relative;
-	padding:8px 0;
-	max-width:1000px;
-	margin:0 auto;
-	padding-right:1.3em;
-	padding-left:1.3em;
+	height: 60px;
+	position: relative;
+	padding: 8px 0;
+	max-width: 1000px;
+	margin: 0 auto;
+	padding-right: 1.3em;
+	padding-left: 1.3em;
 }
+
 .navigationbar {
-	font-family:TradeGothic, Impact, sans-serif;
-	text-transform:uppercase;
-}
-.navigationbar {
-	float:right;
+	float: right;
+	font-family: TradeGothic, Impact, sans-serif;
 	margin-bottom: 0;
 	margin-left: auto;
 	margin-right: auto;
 	margin-top: 2px;
+	text-transform: uppercase;
 }
+
 .navigationbar::after {
 	clear: both;
 }
+
 ul.nav-menu {
 	margin: 0;
 	padding: 0 0 0 0;
 }
+
 .nav-menu li {
 	display: inline-block;
 	position: relative;
 }
+
 .nav-menu li a {
 	display: block;
 	font-size: 16px;
@@ -682,12 +1036,26 @@ ul.nav-menu {
 	padding-top: 10px;
 	padding-left: 12px;
 	padding-right: 12px;
-	color:#000;
+	color: #000;
 	z-index: 99999;
 }
-.nav-menu li:hover > a, .nav-menu li a:hover, .nav-menu li:focus > a, .nav-menu li a:focus {
+
+.nav-menu li:hover > a {
 	color: #eb3b45;
 }
+
+.nav-menu li a:hover {
+	color: #eb3b45;
+}
+
+.nav-menu li:focus > a {
+	color: #eb3b45;
+}
+
+.nav-menu li a:focus {
+	color: #eb3b45;
+}
+
 .nav-menu .sub-menu {
 	background-color: #ffffff;
 	border: none;
@@ -707,51 +1075,71 @@ ul.nav-menu {
 	border-bottom-right-radius: 5px;
 	border-bottom-left-radius: 5px;
 }
+
 ul.nav-menu ul a {
 	color: #000000;
 	margin: 0;
 	width: 200px;
 }
-ul.nav-menu ul a:hover, ul.nav-menu ul a:focus {
+
+ul.nav-menu ul a:hover {
 	color: #eb3b45;
 }
-ul.nav-menu li:hover > ul, .nav-menu ul li:hover > ul {
+
+ul.nav-menu ul a:focus {
+	color: #eb3b45;
+}
+
+ul.nav-menu li:hover > ul {
 	clip: inherit;
 	overflow: inherit;
 	height: inherit;
 	width: inherit;
 }
+
+.nav-menu ul li:hover > ul {
+	clip: inherit;
+	overflow: inherit;
+	height: inherit;
+	width: inherit;
+}
+
 .nav-menu li.apply_top_btn a {
-	background:#d1ab5c;
-	color:#fff !important;
-	padding-left:20px;
-	padding-right:20px;
+	background: #d1ab5c;
+	color: #fff !important;
+	padding-left: 20px;
+	padding-right: 20px;
 	-moz-border-radius: 3px;
 	-webkit-border-radius: 3px;
 	border-radius: 3px;
 	transition: all 0.5s ease 0s;
 }
+
 .nav-menu li.apply_top_btn a:hover {
-	background:#000000;
+	background: #000000;
 }
+
 .nav-menu li.donate_top_btn a {
-	background:#eb3b45;
-	color:#fff !important;
-	padding-left:20px;
-	padding-right:20px;
+	background: #eb3b45;
+	color: #fff !important;
+	padding-left: 20px;
+	padding-right: 20px;
 	-moz-border-radius: 3px;
 	-webkit-border-radius: 3px;
 	border-radius: 3px;
 	transition: all 0.5s ease 0s;
 }
+
 .nav-menu li.donate_top_btn a:hover {
-	background:#000000;
+	background: #000000;
 }
+
 .nav-menu li.beyondz_menu_item {
-	display:none;
+	display: none;
 }
+
 #topheader a.menuicon {
-	display:none;
+	display: none;
 	background: center center no-repeat transparent;
 	background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAMAAAAM7l6QAAAAP1BMVEUAAAD///8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABL3bRJAAAAFHRSTlMAAAUeIGNqi5WxvdDe3+nu8vj6/fn3MBcAAABoSURBVCiRtdPbDYAgEERRFBERZEHov1YzBQxsQry/JyHLy2zDzConYSVw7awKLpSLgieLu5PlwIanYHuwLDg+rAhudPIGFsoCpto7ONysAN5568fiL5ZXTD7Z9+S+88vKipf66y8Z9QEBYx9x/kF/1AAAAABJRU5ErkJggg==);
 	width: 40px;
@@ -760,114 +1148,133 @@ ul.nav-menu li:hover > ul, .nav-menu ul li:hover > ul {
 	top: 10px;
 	right: 10px;
 }
+
 #blogo {
-	float:left;
-	width:185px;
-	height:40px;
+	float: left;
+	width: 185px;
+	height: 40px;
 }
+
 #footer_menu {
-	max-width:980px;
-	margin:0 auto;
+	max-width: 980px;
+	margin: 0 auto;
 }
+
 #footer_bottom.braven_section {
-	background:#262426;
+	background: #262426;
 }
+
 #footer_menu .footer_widget {
-	float:left;
-	width:25%;
+	float: left;
+	width: 25%;
 }
+
 .fb_fico a {
 	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAQAAAD8x0bcAAABQUlEQVQokW2SXyuDYRjGn8lmTWkknDpgTrD4CFtWsoTxDdTKkW8hy58NXwBb42uoCYcspMQRSxOO1c/1svfZ85buk/e97l/X/e8xmFZ0sEKZOxqKW45ZJuTnfGSaC6V2SJFQpCkKr5F0oXne2SBuXb3oo0CTrA9N8cVqAPAjz6fnZohwxWYgFaXb9rOtNsJG7T7SY4GIirxRZ6D1H+eJJcOJ6LbLIHCtyaJWKVExmiLlFFoXVGOOLqvNUDfayqgVhngQ9M0lMaslaAShEJOCTtW4caBXr1zakYYFHQVmzXjlquw60oigagDao2zIaci44/TCgYP08syCIax1bTldxbSrNlTknE7vI6nl5/89yxofTPgHzurABZ3UBfrl32TWP/CfW01zlrS6MUWGfe45Y5zAe/K6yWn4+u+ju+GQxbbrD4aWkJRuvrDpAAAAAElFTkSuQmCC) no-repeat 0 center;
-	opacity:.4;
-	padding-left:25px;
-	color:#fff !important;
+	opacity: .4;
+	padding-left: 25px;
+	color: #fff !important;
 }
+
 .tw_fico a {
 	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAQAAAD8x0bcAAABU0lEQVQokXWSPUsDQRCGN2osJUoarQTBE0Q5tNE6IQEhhNNoY6sQ8B9YiIVFMPgRtbHUGNEfYSUowVKDsVBiZ4r4DXY+zh57lwvEHbjdnXludvedUShjHSxQokpd7J4T5gl5MQ+ZpCyhHWJYYnEKgl9hB6E0r+SI+Fm19ZGnQcqDJvhkuQXwLMuHzqbo5obNtoi2bblGWMl1n+iRbYiwCQyxJNn73XWEGnOKc6GVC+XIyNzJLfDNhvllj1Mlr4j5qX85Yk2+eqSNN0FFiSrDZrtOc7wxaLwW9SA0KiFvXPhXt3jRx8V9xypfLvLDtO9L6uPO2DXbKQ5d5BEnIMI+JSUvqhmtB1gUUR2iAaSXZxwl6pTZ+lfMAtd06YUt4mfbIiu8M+4VOCUFzktJg0BU8jeYCbaKLY1RFXUTjIglOeCBS8Za+0mXJUORitt0dxwz28z6B1ASn4uFLqeWAAAAAElFTkSuQmCC) no-repeat 0 center;
-	opacity:.4;
-	padding-left:25px;
-	color:#fff !important;
+	opacity: .4;
+	padding-left: 25px;
+	color: #fff !important;
 }
+
 .blog_fico a {
 	background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAQAAACMnYaxAAAAxklEQVQYlV3QsQpBURjA8SsLE4My0ZVsKBtlUYpMHsAjsJjuAygjyWhQbPIGshGLhZ1ksVtE/Z17z43vOP863c6vTvd8Fg3u/K8jKSwsixMPRvRES8VjjTc67ofRmjk1ci42vYOCOtBlmKq9zUZjjKwo7ONZYxlHlPDxojFPSxQ30aYqiphYZyhKmxhSv/QraGLz+wz5FA+dvxEE2DHTuOfFgoloq8bX15hjpeYrO6pLowxcdEtSNCrR5clBo81BXf42ulL5AOzyS6X+YSCQAAAAAElFTkSuQmCC) no-repeat 0 center;
-	opacity:.4;
-	padding-left:25px;
-	color:#fff !important;
+	opacity: .4;
+	padding-left: 25px;
+	color: #fff !important;
 }
-.fb_fico a:hover, .tw_fico a:hover, .blog_fico a:hover {
-	opacity:1;
+
+.fb_fico a:hover {
+	opacity: 1;
 }
+
+.tw_fico a:hover {
+	opacity: 1;
+}
+
+.blog_fico a:hover {
+	opacity: 1;
+}
+
 .braven-cc {
-	border-top:1px solid #71716c;
-	padding:20px 0 0;
-	text-align:center;
-	color:#71716c;
+	border-top: 1px solid #71716c;
+	padding: 20px 0 0;
+	text-align: center;
+	color: #71716c;
 }
+
 .braven-cc a {
-	color:#71716c;
+	color: #71716c;
 }
+
 .braven-cc a:hover {
-	color:#fff;
+	color: #fff;
 }
+
 .info_footer_link:before {
 	content: 'Contact us:';
-	display:block;
+	display: block;
 }
+
 .footer_widget {
-	background-color:none;
-	color:#71716c;
+	background-color: none;
+	color: #71716c;
 	font-size: 16px;
 	-webkit-hyphens: auto;
-	-moz-hyphens:    auto;
-	-ms-hyphens:     auto;
-	hyphens:         auto;
+	-moz-hyphens: auto;
+	-ms-hyphens: auto;
+	hyphens: auto;
 	margin: 0 0 0px;
 	padding: 20px;
-	padding-left:0;
-	padding-right:0;
+	padding-left: 0;
+	padding-right: 0;
 	word-wrap: break-word;
 }
+
 .footer_widget .footer-title {
 	font-size: 18px;
 	margin: 0 0 10px;
-	color:#fff;
+	color: #fff;
 }
+
 .footer_widget ul {
 	list-style-type: none;
 	margin: 0;
 	padding: 0;
 }
+
 .footer_widget li {
 	padding: 5px 0;
 }
-.footer_widget a, .footer_widget a:visited {
+
+.footer_widget a {
 	color: #71716c;
 }
+
+.footer_widget a:visited {
+	color: #71716c;
+}
+
 .footer_widget a:hover {
 	color: #fff;
-	text-decoration:none;
-}
-.braven-widget-last {
-}
-a:active, a:hover {
-	color: #000000;
-	outline: 0;
-}
-a:hover {
 	text-decoration: none;
 }
-button, input[type="submit"] {
-	-webkit-appearance: button;
-	border:none;
-	border-radius:2px;
-	cursor: pointer;
-	color:#fff;
+
+.braven-widget-last {
 }
+
 .braven_section {
-	padding:30px 20px;
+	padding: 30px 20px;
 }
+
 button.btn {
-	border:1px solid #111;
+	border: 1px solid #111;
 	-webkit-border-radius: 5px;
 	-moz-border-radius: 5px;
 	border-radius: 5px;
@@ -876,9 +1283,9 @@ button.btn {
 	display: inline-block;
 	text-align: center;
 	vertical-align: middle;
-	font-family:TradeGothic, Impact, sans-serif;
+	font-family: TradeGothic, Impact, sans-serif;
 	font-weight: 400;
-	font-size:21px;
+	font-size: 21px;
 	letter-spacing: 1px;
 	line-height: 1.333em;
 	margin-left: 0;
@@ -892,75 +1299,24 @@ button.btn {
 	text-shadow: none;
 	transition: all 0.5s ease 0s;
 }
-.button-primary, button.btn:hover {
-	background:#000000;
-	color:#fff !important;
-}
-.button-primary {
-	background:#eb3b45;
-	-webkit-border-radius: 5px;
-	-moz-border-radius: 5px;
-	border-radius: 5px;
+
+button.btn:hover {
+	background: #000000;
 	color: #fff !important;
-	cursor: pointer;
-	display: inline-block;
-	text-align: center;
-	vertical-align: middle;
-	font-family:TradeGothic, Impact, sans-serif;
-	font-size:21px;
-	font-weight: 400;
-	letter-spacing: 1px;
-	line-height: 1.333em;
-	margin-left: 0;
-	margin-right: 0;
-	margin-top: 0;
-	padding-bottom: 10px;
-	padding-left: 50px;
-	padding-right: 50px;
-	padding-top: 10px;
-	text-transform: uppercase;
-	text-shadow: none;
-	transition: all 0.5s ease 0s;
 }
-.button-primary:hover {
-	background:#000;
-	color:#fff !important;
-}
-.clear {
-	clear:both;
-}
-.close {
-	background: #eb3b45;
-	color: #FFFFFF !important;
-	line-height: 25px;
-	position: absolute;
-	right: -12px;
-	text-align: center;
-	top: -10px;
-	width: 24px;
-	text-decoration: none;
-	font-weight: bold;
-	-webkit-border-radius: 12px;
-	-moz-border-radius: 12px;
-	border-radius: 12px;
-	-moz-box-shadow: 1px 1px 3px #000;
-	-webkit-box-shadow: 1px 1px 3px #000;
-	box-shadow: 1px 1px 3px #000;
-}
-.close:hover {
-	background: #000;
-}
+
 @media only screen and (max-width: 980px) {
 	#navigation {
-		display:none;
+		display: none;
 	}
 	#topheader a.menuicon {
-		display:block;
+		display: block;
 	}
 	.footer_widget .footer-title {
-		font-size:1em;
+		font-size: 1em;
 	}
 }
+
 @media only screen and (max-width: 650px) {
 	.braven_section {
 		padding-bottom: 5px;
@@ -969,117 +1325,78 @@ button.btn {
 		padding-top: 15px;
 	}
 	ul {
-		padding-left:14px;
+		padding-left: 14px;
 	}
 	#footer_menu {
-		max-width:400px;
-		margin:0 auto;
+		max-width: 400px;
+		margin: 0 auto;
 	}
 	#footer_menu .footer_widget {
-		margin:0 auto;
+		margin: 0 auto;
 		width: 50%;
-		padding-left:4px;
-		padding-right:4px;
+		padding-left: 4px;
+		padding-right: 4px;
 	}
 }
-* {
-	-webkit-box-sizing: border-box;
-	-moz-box-sizing:    border-box;
-	box-sizing:         border-box;
-}
-nav, section {
-	display: block;
-}
-html {
-	font-size: 100%;
-	overflow-y: scroll;
-	-webkit-text-size-adjust: 100%;
-	-ms-text-size-adjust: 100%;
-}
-html, button, input {
-	font-family: "Source Sans Pro", Helvetica, sans-serif;
-}
-body {
-	color: #141412;
-	line-height: 1.5;
-	margin: 0;
-}
-a:focus {
-	outline: thin dotted;
-}
-h2, h3, h4 {
-	clear: both;
-	font-family:  TradeGothic, Impact, "Source Sans Pro", sans-serif;
-	line-height: 1.3;
-	font-weight: 100;
-	text-transform:uppercase;
-}
-h2 {
-	font-size: 30px;
-	margin: 24px 0 10px;
-}
-h3 {
-	font-size: 22px;
-	margin: 21px 0 10px;
-}
-h4 {
-	font-size: 20px;
-	margin: 14px 0;
-}
-ul {
-	margin: 10px 0 25px;
-	padding: 0 0 0 40px;
-}
-ul {
-	list-style: none;
-}
+
 nav ul {
 	list-style: none;
 	list-style-image: none;
 }
+
 li > ul {
 	margin: 0;
 }
-img {
-	-ms-interpolation-mode: bicubic;
-	border: 0;
-	vertical-align: middle;
-}
-form {
-	margin: 0;
-}
-button, input {
-	font-size: 100%;
-	margin: 0;
-	max-width: 100%;
-	vertical-align: baseline;
-}
-button, input {
-	line-height: normal;
-}
-button::-moz-focus-inner, input::-moz-focus-inner {
-	border: 0;
-	padding: 0;
-}
-.clear:after, .navigation:after {
+
+.clear:after {
 	clear: both;
-}
-.clear:before, .clear:after, .navigation:before, .navigation:after {
 	content: "";
 	display: table;
 }
+
+.navigation:after {
+	clear: both;
+	content: "";
+	display: table;
+}
+
+.clear:before {
+	content: "";
+	display: table;
+}
+
+.navigation:before {
+	content: "";
+	display: table;
+}
+
 .navigation a {
 	color: #bc360a;
 }
+
 .navigation a:hover {
 	color: #000000;
 	text-decoration: none;
 }
+
 @media (max-width: 643px) {
 	ul.nav-menu {
 		display: none;
 	}
+
+	.upperheader_red {
+		display: none;
+	}
+
+	main > .plank {
+		padding-top: 0px !important;
+	}
+
+	main > .plank .section-container > section > div.col-md-4 {
+		padding-top: 4px;
+	}
 }
+
 @media print {
 	body {
 		background: none !important;


### PR DESCRIPTION
There's also a reorganization in here brought on by running my css simplifier again... it made it easier to see where the old responsive bit was.

The visual change is on a screen < 640, so phone, it hides the red bar up top and removes some spacing above the form. So it now just shows the Braven logo, the hot dog menu in the corner, then "Platform Login" and the email/password/login buttons without further ado.
