### PR TITLE
Make Docker restarts/rebuilds work when new gem versions are available.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,1 @@
-# Nothing yet. Let's keep the outside and inside the same. If we start running into things that are
-# generated inside the container during the build that we want isolated from the outside, we can
-# add them here to be ignored. Just keep in mind that the whole root app is mounted as a volume,
-# so at runtime, the container will have what's on the outside. This file only affects buildtime.
+Gemfile.lock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     build:
       context: .
     command: /app/docker-compose/scripts/docker_compose_run.sh
+    # Temporarily replace the command above with this if you want the container to just stay open 
+    # so you can connect and troubleshoot b/c the container exits when you bring it up.
+    #tty: true
     ports:
       - "3002:3002"
     # Make changes done outside the container reflect inside the container without needing a rebuild by mounting a volume.


### PR DESCRIPTION
We weren't .dockerignore'ing Gemfile.lock, so when you last built
the Docker image it built whatever Gemfile.lock (which is .gitignored)
into the image. This may not match what `bundle install` installs and things
fail. Just ignore this file in the image build for now. The proper solution
is to check-in Gemfile.lock and have a process for how to update it, but since
we're planning on getting rid of this app/server, I'm not investing time to fix
this up properly.

TESTING:
- Did a fresh docker build (no cache) and it failed to start. Made this change
  and rebuilt. It started.

Foregoing code review b/c there is no code to review.