### PR TITLE
Staging and prod run Ruby 1.9.3. A prior gem I pinned was for Ruby 2.1.

### DIFF
--- a/rubycas-server.gemspec
+++ b/rubycas-server.gemspec
@@ -42,7 +42,8 @@ $gemspec = Gem::Specification.new do |s|
   s.add_development_dependency("appraisal", "~> 0.4.1")
   s.add_development_dependency("guard", "~> 1.4.0")
   s.add_development_dependency("guard-rspec", "2.0.0")
-  s.add_development_dependency("public_suffix", "3.1.1") # Newer versions require Ruby 2.3 or higher. This is a dependency of webmock below (through addressable), so pin it to last version that supports ruby 2.1.
+  #s.add_development_dependency("public_suffix", "3.1.1") # Newer versions require Ruby 2.3 or higher. This is a dependency of webmock below (through addressable), so pin it to last version that supports ruby 2.1.
+  s.add_development_dependency("public_suffix", "1.4.3") # Staging and prod run Ruby 1.9.3. This is the last version supported for that version of ruby, so pin it.
   s.add_development_dependency("webmock", "~> 1.8")
   s.add_development_dependency("nokogiri", "1.6.3.1")
 


### PR DESCRIPTION
Pinning it at the last version supported for Ruby 1.9.3. We had
never done a staging of prod release after the last time I changed this
(or just generally for years and years). So this make this repo at
least deployable to staging and prod even if none of the recent changes
have needed to be deployed b/c they are all for dev env stuff.

TESTING:
- manually made the change on staging and ran `bundle install --path vendor/bundle`
- restarted the server and it worked